### PR TITLE
Added quick share action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.9.1]
+- Long press share button to share cURL command
+
 ## [3.9.0]
 - Bump dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [3.9.1]
-- Long press share button to share cURL command
+- Added `quickShareAction` property. This action will be called on long press on share button. It has AliceHttpCall as argument and should be used to handle share action. By default it will share cURL command.
 
 ## [3.9.0]
 - Bump dependencies

--- a/lib/alice.dart
+++ b/lib/alice.dart
@@ -9,6 +9,7 @@ import 'package:alice_lightweight/model/alice_http_call.dart';
 import 'package:alice_lightweight/utils/alice_custom_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:share_plus/share_plus.dart';
 
 export 'package:alice_lightweight/utils/alice_custom_colors.dart';
 
@@ -43,8 +44,19 @@ class Alice {
     )
     bool darkTheme = false,
     AliceCustomColors customColors = const AliceCustomColors(),
+    void Function(AliceHttpCall aliceHttpCall)? quickShareAction,
   }) {
-    final aliceCore = AliceCore(navigatorKey, customColors);
+    final defaultQuickShareAction = (call) {
+      Share.share(
+        call.getCurlCommand(),
+        subject: 'cURL Command',
+      );
+    };
+    final aliceCore = AliceCore(
+      navigatorKey,
+      customColors,
+      quickShareAction ?? defaultQuickShareAction,
+    );
     final httpClientAdapter = AliceHttpClientAdapter(aliceCore);
     final httpAdapter = AliceHttpAdapter(aliceCore);
 

--- a/lib/core/alice_core.dart
+++ b/lib/core/alice_core.dart
@@ -14,12 +14,18 @@ class AliceCore {
       BehaviorSubject.seeded([]);
   final AliceCustomColors customColors;
 
+  /// Function which will be called on long press on share button.
+  /// It has AliceHttpCall as argument and should be used to handle share action.
+  /// 
+  /// By default it will share cURL command.
+  final void Function(AliceHttpCall aliceHttpCall)? quickShareAction;
+
   GlobalKey<NavigatorState> _navigatorKey;
   bool _isInspectorOpened = false;
   StreamSubscription? _callsSubscription;
 
   /// Creates alice core instance
-  AliceCore(this._navigatorKey, this.customColors);
+  AliceCore(this._navigatorKey, this.customColors, [this.quickShareAction]);
 
   /// Dispose subjects and subscriptions
   void dispose() {

--- a/lib/ui/page/alice_call_details_screen.dart
+++ b/lib/ui/page/alice_call_details_screen.dart
@@ -69,9 +69,9 @@ class _AliceCallDetailsScreenState extends State<AliceCallDetailsScreen>
     return DefaultTabController(
       length: 4,
       child: Scaffold(
-        floatingActionButton: _LongPressHandler(
-          key: Key('long_press_handler_key'),
-          call: call,
+        floatingActionButton: GestureDetector(
+          key: Key('quick_share_action_key'),
+          onLongPress: () => widget.core.quickShareAction?.call(call),
           child: FloatingActionButton(
             backgroundColor: AliceConstants.lightRed(widget.customColors),
             key: Key('share_key'),
@@ -125,26 +125,5 @@ class _AliceCallDetailsScreenState extends State<AliceCallDetailsScreen>
     widgets.add(AliceCallResponseWidget(widget.call, widget.customColors));
     widgets.add(AliceCallErrorWidget(widget.call));
     return widgets;
-  }
-}
-
-class _LongPressHandler extends StatelessWidget {
-  const _LongPressHandler({
-    required this.child,
-    required this.call,
-    super.key,
-  });
-  final AliceHttpCall call;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onLongPress: () => Share.share(
-        call.getCurlCommand(),
-        subject: 'cURL Command',
-      ),
-      child: child,
-    );
   }
 }

--- a/lib/ui/page/alice_call_details_screen.dart
+++ b/lib/ui/page/alice_call_details_screen.dart
@@ -69,14 +69,18 @@ class _AliceCallDetailsScreenState extends State<AliceCallDetailsScreen>
     return DefaultTabController(
       length: 4,
       child: Scaffold(
-        floatingActionButton: FloatingActionButton(
-          backgroundColor: AliceConstants.lightRed(widget.customColors),
-          key: Key('share_key'),
-          onPressed: () async {
-            Share.share(await _getSharableResponseString(),
-                subject: 'Request Details');
-          },
-          child: Icon(Icons.share, color: Colors.white),
+        floatingActionButton: _LongPressHandler(
+          key: Key('long_press_handler_key'),
+          call: call,
+          child: FloatingActionButton(
+            backgroundColor: AliceConstants.lightRed(widget.customColors),
+            key: Key('share_key'),
+            onPressed: () async {
+              Share.share(await _getSharableResponseString(),
+                  subject: 'Request Details');
+            },
+            child: Icon(Icons.share, color: Colors.white),
+          ),
         ),
         appBar: AppBar(
           bottom: TabBar(
@@ -121,5 +125,26 @@ class _AliceCallDetailsScreenState extends State<AliceCallDetailsScreen>
     widgets.add(AliceCallResponseWidget(widget.call, widget.customColors));
     widgets.add(AliceCallErrorWidget(widget.call));
     return widgets;
+  }
+}
+
+class _LongPressHandler extends StatelessWidget {
+  const _LongPressHandler({
+    required this.child,
+    required this.call,
+    super.key,
+  });
+  final AliceHttpCall call;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPress: () => Share.share(
+        call.getCurlCommand(),
+        subject: 'cURL Command',
+      ),
+      child: child,
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: alice_lightweight
 description: Lightweight Alice version. Removed additional dependencies except dio.
-version: 3.9.0
+version: 3.9.1
 homepage: https://github.com/jhomlala/alice
 
 environment:


### PR DESCRIPTION
This simple PR introduces a feature that allows users to set  `quickShareAction`  - a function that will be called on long press on share button. It has AliceHttpCall as argument. By default it will share cURL commands directly by performing a long press on the share button.